### PR TITLE
`create_engine()` now infers from environment and vhost removes leading slash

### DIFF
--- a/mqkit/__init__.py
+++ b/mqkit/__init__.py
@@ -53,6 +53,7 @@ del _consume
 App = apps.App
 Attributes = messaging.Attributes
 create_engine = engines.create_engine
+Engine = engines.Engine
 Exchange = messaging.Exchange
 NoRetry = errors.NoRetry
 Queue = messaging.Queue

--- a/mqkit/consume/decorator.py
+++ b/mqkit/consume/decorator.py
@@ -54,16 +54,6 @@ def _consume_threaded(
         raise worker.error
 
 
-def _infer_engine() -> Engine:
-    # try to infer the engine from an environment variable
-    if "MQKIT_ENGINE_URL" not in os.environ:
-        raise RuntimeError(
-            "No engine provided and MQKIT_ENGINE_URL environment variable not set"
-        )
-
-    return create_engine(os.environ["MQKIT_ENGINE_URL"])
-
-
 def _infer_logger(func: Callable) -> Logger:
     return logging.getLogger(
         os.environ.get(
@@ -110,7 +100,8 @@ def consume(
     """
 
     if engine is None:
-        engine = _infer_engine()
+        # if an engine was not provided, create one based on the environment or defaults
+        engine = create_engine()
 
     codec = CodecType(codec) if codec is not None else CodecType.JSON
 

--- a/mqkit/engines/__init__.py
+++ b/mqkit/engines/__init__.py
@@ -7,12 +7,15 @@ based on connection URLs.
 
 __all__ = ["create_engine", "Engine", "RabbitMqEngine"]
 
-from typing import Dict, Type
+import os
+from typing import Dict, Optional, Type
 
 from yarl import URL
 
 from .engine import Engine
 from .rabbitmq import RabbitMqEngine
+
+from ..errors import ConfigurationError
 
 
 _scheme_mapping: Dict[str, Type[Engine]] = {
@@ -21,7 +24,7 @@ _scheme_mapping: Dict[str, Type[Engine]] = {
 }
 
 
-def create_engine(url: str) -> Engine:
+def create_engine(url: Optional[str] = None) -> Engine:
     """
     Factory method to create an Engine instance based on the provided URL.
 
@@ -31,6 +34,15 @@ def create_engine(url: str) -> Engine:
     Returns:
         Engine: An instance of the appropriate Engine subclass.
     """
+
+    # try to infer the engine if no URL is provided
+    if url is None:
+        if "MQKIT_ENGINE_URL" not in os.environ:
+            raise ConfigurationError(
+                "No engine URL provided and MQKIT_ENGINE_URL environment variable not set"
+            )
+
+        url = os.environ["MQKIT_ENGINE_URL"]
 
     connect_url: URL = URL(url)
     if connect_url.scheme not in _scheme_mapping:

--- a/mqkit/engines/rabbitmq/rabbitmqengine.py
+++ b/mqkit/engines/rabbitmq/rabbitmqengine.py
@@ -72,7 +72,9 @@ class RabbitMqEngine(Engine):
             "use_amqps": url.scheme == "amqps",
         }
         if url.path not in (None, ""):
-            ctor_args["vhost"] = url.path
+            # strip the leading slash from the path to get the actual vhost name. we
+            # don't want to do this for the root vhost since it's just "/"
+            ctor_args["vhost"] = url.path[1:] if url.path != "/" else "/"
         if url.port is not None:
             ctor_args["port"] = url.port
         elif url.scheme == "amqps":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mqkit"
-version = "0.1.1"
+version = "0.1.2"
 description = "Framework for building FastAPI-style RabbitMQ apps"
 authors = [
     {name = "Will Hinson",email = "will@hinson.sh"}

--- a/tests/consume/test_consume.py
+++ b/tests/consume/test_consume.py
@@ -6,7 +6,7 @@ import pytest
 from unittest.mock import Mock, patch
 
 from mqkit import consume
-from mqkit.consume.decorator import _consume_threaded, _infer_engine, _infer_logger
+from mqkit.consume.decorator import _consume_threaded, _infer_logger
 from mqkit.endpoints.config import QueueEndpointConfig
 from mqkit.marshal.codecs import CodecType
 
@@ -60,23 +60,6 @@ def test_consume_threaded_reraises_worker_error(mocker) -> None:
         )
 
 
-def test_infer_engine_env_not_set() -> None:
-    with patch.dict(os.environ, {}, clear=True):
-        with pytest.raises(RuntimeError, match="MQKIT_ENGINE_URL"):
-            _infer_engine()
-
-
-def test_infer_engine_env_set(mocker) -> None:
-    mock_create_engine = mocker.patch(
-        "mqkit.consume.decorator.create_engine", return_value="engine"
-    )
-    with patch.dict(os.environ, {"MQKIT_ENGINE_URL": "amqp://test"}):
-        result = _infer_engine()
-
-    assert result == "engine"
-    mock_create_engine.assert_called_once_with("amqp://test")
-
-
 def test_infer_logger_default_name():
     def fake_func(): ...
 
@@ -96,7 +79,9 @@ def test_infer_logger_env_name():
     assert logger.name == "my_logger"
 
 
-def test_consume_decorator_async_disallowed() -> None:
+def test_consume_decorator_async_disallowed(mocker) -> None:
+    mocker.patch("mqkit.consume.decorator.create_engine", return_value="engine")
+
     async def async_handler(msg):
         return msg
 
@@ -108,8 +93,8 @@ def test_consume_decorator_blocks_safely(mocker) -> None:
     # patch the blocking pieces BEFORE decorating
     mock_threaded = mocker.patch("mqkit.consume.decorator._consume_threaded")
     mock_exit = mocker.patch("sys.exit")
-    mock_infer_engine = mocker.patch(
-        "mqkit.consume.decorator._infer_engine", return_value="engine"
+    mock_create_engine = mocker.patch(
+        "mqkit.consume.decorator.create_engine", return_value="engine"
     )
     mock_infer_logger = mocker.patch(
         "mqkit.consume.decorator._infer_logger", return_value=Mock()
@@ -126,7 +111,7 @@ def test_consume_decorator_blocks_safely(mocker) -> None:
     # decorated()
 
     # assertions
-    mock_infer_engine.assert_called_once()
+    mock_create_engine.assert_called_once()
     mock_infer_logger.assert_called_once_with(handler)
     mock_threaded.assert_called_once()
 

--- a/tests/engines/test_engine.py
+++ b/tests/engines/test_engine.py
@@ -1,8 +1,12 @@
 import inspect
+import os
 
-from mqkit.engines import Engine
+from mqkit import create_engine, Engine
+from mqkit.engines import RabbitMqEngine
+from mqkit.errors import ConfigurationError
 
 import pytest
+from unittest.mock import patch
 
 
 def test_connection_is_abstract_base_class() -> None:
@@ -18,3 +22,23 @@ def test_connection_is_abstract_base_class() -> None:
             getattr(Engine, function)(
                 *([None] * len(inspect.signature(getattr(Engine, function)).parameters))
             )
+
+
+def test_engine_infer_env_not_set() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ConfigurationError, match="MQKIT_ENGINE_URL"):
+            create_engine()
+
+
+def test_engine_infer_env_set() -> None:
+    with patch.dict(
+        os.environ, {"MQKIT_ENGINE_URL": "amqp://user:password@test:1234/vhost"}
+    ):
+        result = create_engine()
+
+    assert isinstance(result, RabbitMqEngine)
+    assert result.host == "test"
+    assert result.port == 1234
+    assert result.vhost == "vhost"
+    assert result.credentials.username == "user"
+    assert result.credentials.password == "password"


### PR DESCRIPTION
closes #63 and #64 