### PR TITLE
Moved shared DLQ header behavior to `RetryStrategy`

### DIFF
--- a/mqkit/messaging/retry/immediateretrystrategy.py
+++ b/mqkit/messaging/retry/immediateretrystrategy.py
@@ -7,12 +7,9 @@ to fail after exceeding the maximum retries, it can be forwarded to an optional 
 destination for further analysis or handling.
 """
 
-import traceback
 from typing import override
 
 from ...errors import ConfigurationError, MarshalError
-from ..exceptionhistoryentry import ExceptionHistoryEntry
-from ..forward import Forward
 from .retrycontext import RetryContext
 from .retrystrategy import RetryStrategy
 
@@ -61,52 +58,6 @@ class ImmediateRetryStrategy(RetryStrategy):
         # original message to remove it from the queue since we have requeued it
         self._submit_for_retry(context)
         context.connection.acknowledge_failure(context.message)
-
-    def _append_exception_to_history(
-        self: "ImmediateRetryStrategy", context: RetryContext
-    ) -> None:
-        # append an object representing the current exception to the history
-        context.message.attributes.exception_history.append(
-            ExceptionHistoryEntry(
-                exception_type=type(context.exception).__qualname__,
-                exception_module=type(context.exception).__module__,
-                exception_message=str(context.exception),
-                traceback=traceback.format_exception(context.exception),
-                retry_count=context.message.attributes.retry_count,
-            )
-        )
-
-    def _forward_to_dlq(self: "ImmediateRetryStrategy", context: RetryContext) -> None:
-        if context.dead_letter_destination is None:
-            self._logger.warning(
-                "No dead letter destination configured, message will be discarded"
-            )
-        else:
-            self._logger.info(
-                "Forwarding failed message to dead letter destination: %s",
-                context.dead_letter_destination,
-            )
-
-            # set up the message with the appropriate dlq context
-            if context.dead_letter_destination.topic is not None:
-                context.message.attributes.topic = context.dead_letter_destination.topic
-            context.message.attributes.headers["x-mqkit-previous-retry-count"] = str(
-                context.message.attributes.retry_count
-            )
-            context.message.attributes.headers |= {
-                "x-mqkit-forwarded": "true",
-                "x-mqkit-dead-letter": "true",
-                "x-mqkit-origin-queue": context.received_queue,
-            }
-            self._append_exception_to_history(context)
-            context.message.attributes.retry_count = 0
-
-            context.connection.forward_message(
-                Forward(
-                    forward_target=context.dead_letter_destination.resource,
-                    message=context.message,
-                )
-            )
 
     def _handle_failure_bad_message(
         self: "ImmediateRetryStrategy", context: RetryContext

--- a/mqkit/messaging/retry/noretrystrategy.py
+++ b/mqkit/messaging/retry/noretrystrategy.py
@@ -8,7 +8,6 @@ message handler.
 
 from typing import override
 
-from ..forward import Forward
 from .retrycontext import RetryContext
 from .retrystrategy import RetryStrategy
 
@@ -28,19 +27,7 @@ class NoRetryStrategy(RetryStrategy):
 
     @override
     def handle_failure(self: "NoRetryStrategy", context: RetryContext) -> None:
-        if context.dead_letter_destination is not None:
-            self._logger.info(
-                "Message failed, forwarding to dead letter destination %s. Will not retry",
-                context.dead_letter_destination,
-            )
-            context.connection.forward_message(
-                Forward(
-                    forward_target=context.dead_letter_destination.resource,
-                    message=context.message,
-                )
-            )
-        else:
-            self._logger.info("Acknowledged failure of message, will not retry")
+        self._forward_to_dlq(context)
 
         # simply acknowledge failure on the existing connection. we never
         # want to retry with this strategy

--- a/mqkit/messaging/retry/retrystrategy.py
+++ b/mqkit/messaging/retry/retrystrategy.py
@@ -9,7 +9,10 @@ RetryStrategy can implement different retry policies
 from abc import ABCMeta, abstractmethod
 from logging import Logger
 import logging
+import traceback
 
+from ..exceptionhistoryentry import ExceptionHistoryEntry
+from ..forward import Forward
 from ...logging import root_logger_name
 from .retrycontext import RetryContext
 
@@ -32,6 +35,52 @@ class RetryStrategy(metaclass=ABCMeta):
             f"{root_logger_name}.{'.'.join(self.__class__.__module__.split('.')[1:-1])}."
             f"{self.__class__.__name__}"
         )
+
+    def _append_exception_to_history(
+        self: "RetryStrategy", context: RetryContext
+    ) -> None:
+        # append an object representing the current exception to the history
+        context.message.attributes.exception_history.append(
+            ExceptionHistoryEntry(
+                exception_type=type(context.exception).__qualname__,
+                exception_module=type(context.exception).__module__,
+                exception_message=str(context.exception),
+                traceback=traceback.format_exception(context.exception),
+                retry_count=context.message.attributes.retry_count,
+            )
+        )
+
+    def _forward_to_dlq(self: "RetryStrategy", context: RetryContext) -> None:
+        if context.dead_letter_destination is None:
+            self._logger.warning(
+                "No dead letter destination configured, message will be discarded"
+            )
+        else:
+            self._logger.info(
+                "Forwarding failed message to dead letter destination: %s",
+                context.dead_letter_destination,
+            )
+
+            # set up the message with the appropriate dlq context
+            if context.dead_letter_destination.topic is not None:
+                context.message.attributes.topic = context.dead_letter_destination.topic
+            context.message.attributes.headers["x-mqkit-previous-retry-count"] = str(
+                context.message.attributes.retry_count
+            )
+            context.message.attributes.headers |= {
+                "x-mqkit-forwarded": "true",
+                "x-mqkit-dead-letter": "true",
+                "x-mqkit-origin-queue": context.received_queue,
+            }
+            self._append_exception_to_history(context)
+            context.message.attributes.retry_count = 0
+
+            context.connection.forward_message(
+                Forward(
+                    forward_target=context.dead_letter_destination.resource,
+                    message=context.message,
+                )
+            )
 
     @abstractmethod
     def handle_failure(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mqkit"
-version = "0.1.3"
+version = "0.1.4"
 description = "Framework for building FastAPI-style RabbitMQ apps"
 authors = [
     {name = "Will Hinson",email = "will@hinson.sh"}

--- a/tests/common/__init__.py
+++ b/tests/common/__init__.py
@@ -78,6 +78,21 @@ class ManagedQueue:
         assert response.ok or response.status_code == 404
         return "messages" in response.json()
 
+    def get_one(self: "ManagedQueue") -> dict:
+        response: Response = requests.post(
+            build_management_url(f"/api/queues/%2F/{self.name}/get"),
+            auth=(TEST_USERNAME, TEST_PASSWORD),
+            json={
+                "count": 1,
+                "ackmode": "ack_requeue_false",
+                "encoding": "auto",
+            },
+        )
+        assert response.ok, "Failed to get message from the queue"
+        messages = response.json()
+        assert len(messages) > 0, "No messages in the queue"
+        return messages[0]
+
     def publish(
         self: "ManagedQueue", message: str, headers: dict | None = None
     ) -> None:

--- a/tests/retries/test_noretrystrategy.py
+++ b/tests/retries/test_noretrystrategy.py
@@ -69,4 +69,7 @@ def test_noretrystrategy_dlq_forward(rabbitmq_engine: RabbitMqEngine) -> None:
         wait_to_assert(lambda: retry_count == 1, timeout=ASSERT_TIMEOUT)
         wait_to_assert(lambda: managed_queue.size == 0, timeout=ASSERT_TIMEOUT)
         wait_to_assert(lambda: dlq.size == 1, timeout=ASSERT_TIMEOUT)
+        assert len(dlq.get_one()["properties"]["headers"]) > 0, (
+            "Expected message to have headers added by retry strategy when forwarded to DLQ"
+        )
         app.stop()


### PR DESCRIPTION
closes #73 